### PR TITLE
Explicitly include the in_place_factory.hpp

### DIFF
--- a/src/nodelet_rosbag.cpp
+++ b/src/nodelet_rosbag.cpp
@@ -1,4 +1,5 @@
 #include <boost/foreach.hpp>
+#include <boost/utility/in_place_factory.hpp>
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 #include <rosbag/view.h>


### PR DESCRIPTION
Explicitly include the in_place_factory.hpp which is no longer included by the optional headers.